### PR TITLE
token: Use no SI prefix for zero value

### DIFF
--- a/src/token.c
+++ b/src/token.c
@@ -876,7 +876,9 @@ _nk_token_list_append_prettify(GString *string, GVariant *data, NkTokenPrettify 
     case NK_TOKEN_PRETTIFY_PREFIXES_SI:
     {
         const gchar **prefix;
-        if ( ( value > -1 ) && ( value < 1 ) )
+        if ( value == 0 )
+            prefix = _nk_token_prefixes_si_small; /* Empty string */
+        else if ( ( value > -1 ) && ( value < 1 ) )
         {
             for ( prefix = _nk_token_prefixes_si_small ; ( value > -1 ) && ( value < 1 ) && ( prefix < ( _nk_token_prefixes_si_small + G_N_ELEMENTS(_nk_token_prefixes_si_small) ) ) ; ++prefix )
                 value *= 1000;


### PR DESCRIPTION
When zero value was passed to _nk_token_list_append_prettify(), the
search for a proper SI prefix in _nk_token_prefixes_si_small run out
of array bounds. In my case, it manifested as bitrate string of
"0(null)b/s".

This is now fixed by explicit check for zero value and setting of
empty prefix in this case.

Signed-off-by: Michal Sojka <michal.sojka@cvut.cz>